### PR TITLE
fix(dockerfile): install matplotlib via apk to restore STL/3MF preview rendering

### DIFF
--- a/printernizer/Dockerfile
+++ b/printernizer/Dockerfile
@@ -95,6 +95,7 @@ RUN apk update && \
     else \
         apk add --no-cache \
             python3 py3-pip py3-brotli \
+            py3-matplotlib ttf-dejavu \
             sqlite curl jq bash tzdata ffmpeg \
             openblas lapack libgfortran libstdc++ && \
         rm -rf /var/cache/apk/*; \


### PR DESCRIPTION
Since requirements.txt no longer includes matplotlib (dropped upstream in v2.32.2
to avoid Alpine/musl source-build failures on aarch64), install it via Alpine's
prebuilt py3-matplotlib package instead. Also adds ttf-dejavu for font support.
This lands matplotlib in the final runtime image for aarch64/amd64 without any
compilation step, restoring preview_render_service.py functionality.

https://claude.ai/code/session_01UxCwfwn6Lk8SiFQxwuAPqE