### PR TITLE
Swap add-on runtime deps from OpenSCAD to build123d (Debian)

### DIFF
--- a/printernizer/Dockerfile
+++ b/printernizer/Dockerfile
@@ -1,5 +1,9 @@
 # Printernizer - Home Assistant Add-on
-# Debian (glibc) base for openscad + matplotlib support on all arches (amd64, aarch64, armv7)
+# Debian (glibc) base. Required by the build123d model generator: it depends on
+# OpenCascade via the OCP bindings, which ship manylinux (glibc) wheels only
+# (no musllinux build), so an Alpine base is not an option. matplotlib STL/3MF
+# previews also work here (no musl/aarch64 wheel constraint). All on amd64,
+# aarch64 and armv7.
 
 # ============================================
 # Stage 1: Builder - Compile dependencies
@@ -29,8 +33,9 @@ COPY requirements.txt /tmp/
 # Install Python packages from requirements.txt.
 # Prefer pre-built binary wheels; fall back to source only if needed.
 # piwheels provides ARM wheels (arm64/armhf) for packages without official ones.
-# matplotlib is NOT in requirements.txt (excluded upstream for musl/aarch64 compat)
-# but works on Debian/glibc, so install it here for STL/3MF preview rendering.
+# matplotlib and build123d are NOT in requirements.txt (excluded upstream for
+# musl/armv7 wheel compatibility) but work on Debian/glibc, so they are installed
+# here as optional extras.
 RUN pip3 install --no-cache-dir --user --break-system-packages \
         --prefer-binary \
         --extra-index-url https://www.piwheels.org/simple \
@@ -41,6 +46,16 @@ RUN pip3 install --no-cache-dir --user --break-system-packages \
         --prefer-binary \
         --default-timeout=300 \
         matplotlib
+
+# Optional: build123d (parametric model generator). cadquery-ocp ships glibc
+# wheels for x86_64/aarch64 only — there is no 32-bit armv7 wheel — so this is
+# best-effort: on armv7 it is skipped and the generator reports itself
+# unavailable (graceful degradation), keeping the armv7 image building.
+RUN pip3 install --no-cache-dir --user --break-system-packages \
+        --prefer-binary \
+        --default-timeout=300 \
+        "build123d>=0.9.1" \
+    || echo "build123d not installable on this architecture; model generator disabled"
 
 # ============================================
 # Stage 2: Runtime - Lean production image
@@ -57,12 +72,11 @@ ENV LANG=C.UTF-8 \
     PATH=/root/.local/bin:$PATH
 
 # Install runtime dependencies.
-# openscad is available in Debian repos for amd64, arm64, and armhf (all supported arches).
-# xvfb provides xvfb-run for headless OpenSCAD PNG rendering.
+# libgl1/libglu1-mesa/libxrender1/libxext6/libsm6/libgomp1/fontconfig are
+# required by OpenCascade/OCP (the build123d model generator). No external
+# CAD binary is needed — build123d renders geometry in-process.
 RUN apt-get update && apt-get install -y --no-install-recommends \
         python3 \
-        openscad \
-        xvfb \
         sqlite3 \
         curl \
         jq \
@@ -73,6 +87,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         libopenblas0 \
         libgfortran5 \
         libstdc++6 \
+        libgl1 \
+        libglu1-mesa \
+        libxrender1 \
+        libxext6 \
+        libsm6 \
+        libgomp1 \
+        fontconfig \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy compiled Python packages from builder stage

--- a/printernizer/build.yaml
+++ b/printernizer/build.yaml
@@ -1,6 +1,7 @@
 # Printernizer - Multi-Architecture Build Configuration
-# Debian (glibc) base images: openscad packages exist for amd64, arm64, armhf
-# so the Generator feature and matplotlib STL previews work on all arches.
+# Debian (glibc) base images are required: the build123d model generator depends
+# on OpenCascade/OCP (manylinux/glibc wheels only, no musllinux build). matplotlib
+# STL previews also work on glibc. Covers amd64, aarch64 (arm64) and armv7.
 
 build_from:
   aarch64: ghcr.io/home-assistant/aarch64-base-debian:latest


### PR DESCRIPTION
## Summary
The model generator now uses **build123d** instead of the `openscad` binary. This updates the HA add-on's Docker build accordingly (the `src/`, `frontend/`, `migrations/` come via auto-sync from [printernizer#354](https://github.com/schmacka/printernizer/pull/354)).

- Drop `openscad` and `xvfb` from the runtime image; add the OpenCascade/OCP runtime libraries (`libgl1`, `libglu1-mesa`, `libxrender1`, `libxext6`, `libsm6`, `libgomp1`, `fontconfig`).
- Install build123d **best-effort** in the builder stage: cadquery-ocp has no 32-bit armv7 wheel, so on armv7 it is skipped and the generator degrades gracefully — keeping the armv7 image building. Stays on the Debian base.

## Note
Merge order: this pairs with printernizer#354. The application code arrives via the auto-sync workflow once that lands on `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)