### PR TITLE
feat: add slicer_service_url option (reach the slicer add-on)

### DIFF
--- a/printernizer/config.yaml
+++ b/printernizer/config.yaml
@@ -46,6 +46,7 @@ options:
   timelapse_auto_process_timeout: 300
   timelapse_cleanup_age_days: 30
   job_creation_auto_create: true
+  slicer_service_url: ""
 
 schema:
   log_level: list(debug|info|warning|error)?
@@ -59,6 +60,7 @@ schema:
   timelapse_auto_process_timeout: int(60,3600)?
   timelapse_cleanup_age_days: int(1,365)?
   job_creation_auto_create: bool?
+  slicer_service_url: str?
 
 # Image configuration
 # Pull the pre-built, CI-published per-arch images instead of building locally.

--- a/printernizer/run.sh
+++ b/printernizer/run.sh
@@ -23,6 +23,7 @@ TIMELAPSE_OUTPUT_FOLDER=$(bashio::config 'timelapse_output_folder' '/data/timela
 TIMELAPSE_OUTPUT_STRATEGY=$(bashio::config 'timelapse_output_strategy' 'separate')
 TIMELAPSE_AUTO_PROCESS_TIMEOUT=$(bashio::config 'timelapse_auto_process_timeout' '300')
 TIMELAPSE_CLEANUP_AGE_DAYS=$(bashio::config 'timelapse_cleanup_age_days' '30')
+SLICER_SERVICE_URL=$(bashio::config 'slicer_service_url' '')
 
 bashio::log.info "Configuration loaded from Home Assistant"
 bashio::log.info "  • Log Level: ${LOG_LEVEL}"
@@ -70,6 +71,9 @@ HA_INGRESS=true
 # Server configuration
 HOST=0.0.0.0
 PORT=8000
+
+# Slicer service (the Printernizer Slicer add-on); empty = slicing disabled
+SLICER_SERVICE_URL=${SLICER_SERVICE_URL}
 
 # Logging
 LOG_LEVEL=${LOG_LEVEL}


### PR DESCRIPTION
Adds a slicer_service_url add-on option that writes SLICER_SERVICE_URL into the app env (empty = slicing disabled). Pairs with the new Printernizer Slicer add-on so HA users can run slicing on the Pi.