### PR TITLE
fix: matplotlib deps missing in addon image (STL previews)

### DIFF
--- a/printernizer/Dockerfile
+++ b/printernizer/Dockerfile
@@ -47,7 +47,13 @@ RUN pip3 install --no-cache-dir --user --break-system-packages \
 # so armv7 can use a prebuilt wheel; on any arch without a wheel it would build
 # from source (needs freetype + patch/git), so failures are non-fatal and preview
 # rendering simply degrades gracefully.
+# --ignore-installed forces matplotlib's FULL dependency tree (packaging,
+# pyparsing, python-dateutil, etc.) into /root/.local. Without it, deps already
+# satisfied by a system package in the builder are skipped and never copied to
+# the final stage (COPY --from=builder /root/.local), so matplotlib fails to
+# import at runtime ("No module named 'packaging'") and STL previews silently break.
 RUN pip3 install --no-cache-dir --user --break-system-packages \
+        --ignore-installed \
         --prefer-binary \
         --extra-index-url https://www.piwheels.org/simple \
         --trusted-host www.piwheels.org \


### PR DESCRIPTION
matplotlib was installed but its 'packaging' dep wasn't copied to the final stage (system-satisfied in builder, only /root/.local is copied). --ignore-installed forces the full dep tree into /root/.local so matplotlib imports and STL thumbnails render. Verified in the published image: matplotlib present but 'No module named packaging'.