### PR TITLE
chore: Stop Dependabot pip updates on auto-synced /printernizer path

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,10 @@
 version: 2
 updates:
-  # Python dependencies
-  - package-ecosystem: "pip"
-    directory: "/printernizer"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 10
+  # NOTE: pip updates for /printernizer are intentionally NOT configured here.
+  # printernizer/requirements.txt is auto-synced from the upstream printernizer
+  # repo (see .github/workflows/sync-to-ha-repo.yml there). Dependabot PRs
+  # against it always conflict with the sync and go stale, so Python dependency
+  # updates are handled by Dependabot in the upstream repo instead.
 
   # Docker dependencies
   - package-ecosystem: "docker"


### PR DESCRIPTION
## Summary
Removes the `pip` Dependabot config for `/printernizer`, because `printernizer/requirements.txt` is **auto-synced** from the upstream [printernizer](https://github.com/schmacka/printernizer) repo (`sync-to-ha-repo.yml`). Dependabot PRs against a synced file always conflict with the sync and go stale — that's the root cause of the #20–#29 backlog (and why #21/#27 had to be closed as superseded/obsolete).

Python dependency updates are already handled by Dependabot in the upstream repo, which is the single source of truth for `requirements.txt`.

## Kept
- **docker** (`/printernizer`) — targets the HA-specific `Dockerfile` (not synced).
- **github-actions** (`/`) — targets this repo's own workflows (not synced).

Validated as well-formed YAML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)